### PR TITLE
Added some missing cases to manga name check

### DIFF
--- a/app/src/test/java/eu/kanade/tachiyomi/data/database/CategoryTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/database/CategoryTest.kt
@@ -150,24 +150,24 @@ class CategoryTest {
     
     private fun createManga(m: Manga, title: String) {
         m.title = title
-        m.author = ""
-        m.artist = ""
-        m.thumbnail_url = ""
-        m.genre = "a list of genres"
-        m.description = "long description"
-        m.url = "url to manga"
+        m.author = "createMangaAuthor"
+        m.artist = "createMangaArtist"
+        m.thumbnail_url = "createMangaThumbnail"
+        m.genre = "createManga genre list"
+        m.description = "createManga long discription"
+        m.url = "createMangaUrl"
         m.favorite = true
         db.insertManga(m).executeAsBlocking()
     }
 
     private fun createNonfavoriteManga(m: Manga, title: String) {
         m.title = title
-        m.author = ""
-        m.artist = ""
-        m.thumbnail_url = ""
-        m.genre = "a list of genres"
-        m.description = "long description"
-        m.url = "url to manga"
+        m.author = "createNonfavoriteMangaAuthor"
+        m.artist = "createNonfavoriteMangaArtist"
+        m.thumbnail_url = "createNonfavoriteMangaThumbnail"
+        m.genre = "createNonfavoriteManga genre list"
+        m.description = "createNonfavoriteManga long discription"
+        m.url = "createNonfavoriteMangaUrl"
         m.favorite = false
         db.insertManga(m).executeAsBlocking()
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/database/ChapterRecognitionTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/database/ChapterRecognitionTest.kt
@@ -48,6 +48,30 @@ class ChapterRecognitionTest {
     }
 
     /**
+     * Ch.xx check if result is consistent across multiple runs of ChapterRecognition
+     */
+    @Test fun recheckTest() {
+        createManga("Test Manga Name")
+
+        createChapter("Test Manga Name Vol.1 Ch.4: Misrepresentation")
+        for (i in 1..5) {
+            ChapterRecognition.parseChapterNumber(chapter, manga)
+            assertThat(chapter.chapter_number).isEqualTo(4f)
+        }
+    }
+
+    /**
+     * Ch.xx check if manga name removed from chapter name
+     */
+    @Test fun checkMangaNameRemovalTest() {
+        createManga("Test Manga Name")
+
+        createChapter("Test Manga Name Vol.1 Ch.4: Misrepresentation")
+        ChapterRecognition.parseChapterNumber(chapter, manga)
+        assertThat(chapter.name).isEqualTo("Vol.1 Ch.4: Misrepresentation")
+    }
+
+    /**
      * Ch.xx base case
      */
     @Test fun ChCaseBase() {
@@ -331,6 +355,15 @@ class ChapterRecognitionTest {
      */
     @Test fun unParsableCase() {
         createChapter("Foo")
+        ChapterRecognition.parseChapterNumber(chapter, manga)
+        assertThat(chapter.chapter_number).isEqualTo(-1f)
+    }
+
+    /**
+     * empty chapter
+     */
+    @Test fun emptyCase() {
+        createChapter("")
         ChapterRecognition.parseChapterNumber(chapter, manga)
         assertThat(chapter.chapter_number).isEqualTo(-1f)
     }


### PR DESCRIPTION
Lot of features of the ChapterRecognition were untested, starting to adress that. I tried to remove the need for the ChapterRecognition to be specifically called as well but it looks like that code is a bit more scattered around than expected so those changes aren't ready yet.